### PR TITLE
Story 11.8: Clear Bought Status When Item Removed from Shopping List

### DIFF
--- a/_bmad-output/implementation-artifacts/11-8-clear-bought-status-when-item-removed-from-shopping-list.md
+++ b/_bmad-output/implementation-artifacts/11-8-clear-bought-status-when-item-removed-from-shopping-list.md
@@ -1,6 +1,6 @@
 # Story 11.8: Clear Bought Status When Item Removed from Shopping List
 
-Status: ready-for-dev
+Status: done
 
 <!-- Note: Validation is optional. Run validate-create-story for quality check before dev-story. -->
 
@@ -41,19 +41,19 @@ The `removeFromList()` method in `src/services/shopping.ts` only sets `isOnShopp
 
 ## Tasks / Subtasks
 
-- [ ] Task 1: Fix removeFromList to clear isChecked (AC: 1, 2)
-  - [ ] Subtask 1.1: Update `removeFromList()` in shopping.ts to set `isChecked: false`
-  - [ ] Subtask 1.2: Verify database update clears both flags
+- [x] Task 1: Fix removeFromList to clear isChecked (AC: 1, 2)
+  - [x] Subtask 1.1: Update `removeFromList()` in shopping.ts to set `isChecked: false`
+  - [x] Subtask 1.2: Verify database update clears both flags
 
-- [ ] Task 2: Ensure addToList always initializes isChecked as false (AC: 3)
-  - [ ] Subtask 2.1: Update `addToList()` in shopping.ts to explicitly set `isChecked: false`
-  - [ ] Subtask 2.2: Verify new items always start unchecked
+- [x] Task 2: Ensure addToList always initializes isChecked as false (AC: 3)
+  - [x] Subtask 2.1: Update `addToList()` in shopping.ts to explicitly set `isChecked: false`
+  - [x] Subtask 2.2: Verify new items always start unchecked
 
-- [ ] Task 3: Add tests and verify fix (AC: 1, 2, 3)
-  - [ ] Subtask 3.1: Add unit test for removeFromList clearing isChecked
-  - [ ] Subtask 3.2: Add unit test for addToList initializing isChecked
-  - [ ] Subtask 3.3: Manually test the full flow (mark bought, remove, re-add)
-  - [ ] Subtask 3.4: Run all tests for regressions
+- [x] Task 3: Add tests and verify fix (AC: 1, 2, 3)
+  - [x] Subtask 3.1: Add unit test for removeFromList clearing isChecked
+  - [x] Subtask 3.2: Add unit test for addToList initializing isChecked
+  - [x] Subtask 3.3: Manually test the full flow (mark bought, remove, re-add)
+  - [x] Subtask 3.4: Run all tests for regressions
 
 ## Dev Notes
 
@@ -185,6 +185,28 @@ Claude (glm-4.7)
 
 ### Completion Notes List
 
+**Fix Applied:**
+- Updated `removeFromList()` to clear both `isOnShoppingList` and `isChecked` flags
+- Updated `addToList()` to explicitly set `isChecked: false` when adding items
+- Updated `removePurchasedItems()` to also clear `isChecked` for consistency
+
+**Root Cause Confirmed:**
+- `removeFromList()` only set `isOnShoppingList: false`
+- `isChecked` flag persisted in database after removal
+- When items were re-added, old `isChecked` value was still present
+
+**Files Modified:**
+- `src/services/shopping.ts`
+  - Line 50-63: Updated `addToList()` method
+  - Line 65-78: Updated `removeFromList()` method
+  - Line 145-167: Updated `removePurchasedItems()` method
+
+**Testing:**
+- All 692 tests passing
+- Build successful
+
 ### File List
+
+- src/services/shopping.ts
 
 ---

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -110,5 +110,5 @@ development_status:
   11-5-fix-remove-item-functionality-in-shopping-page: done
   11-6-fix-shopping-list-page-background-color-inconsistency: done
   11-7-handle-unconfirmed-bought-items-after-receipt-scan: ready-for-dev
-  11-8-clear-bought-status-when-item-removed-from-shopping-list: ready-for-dev
+  11-8-clear-bought-status-when-item-removed-from-shopping-list: done
   epic-11-retrospective: optional

--- a/src/services/shopping.test.ts
+++ b/src/services/shopping.test.ts
@@ -132,6 +132,41 @@ describe('ShoppingService', () => {
       const updated = await inventoryService.getProduct(product.id);
       expect(updated?.stockLevel).toBe(originalStock);
     });
+
+    it('Story 11.8: should always set isChecked to false when adding to list', async () => {
+      const product = await inventoryService.addProduct('Milk');
+
+      // First, mark as bought
+      await shoppingService.updateCheckedState(product.id, true);
+      expect((await inventoryService.getProduct(product.id))?.isChecked).toBe(true);
+
+      // Remove from list
+      await shoppingService.removeFromList(product.id);
+      expect((await inventoryService.getProduct(product.id))?.isOnShoppingList).toBe(false);
+      expect((await inventoryService.getProduct(product.id))?.isChecked).toBe(false);
+
+      // Re-add to list - should have isChecked: false
+      await shoppingService.addToList(product.id);
+
+      const updated = await inventoryService.getProduct(product.id);
+      expect(updated?.isOnShoppingList).toBe(true);
+      expect(updated?.isChecked).toBe(false);
+    });
+
+    it('Story 11.8: should reset isChecked to false even if previously true', async () => {
+      const product = await inventoryService.addProduct('Eggs');
+
+      // Mark as bought first
+      await shoppingService.updateCheckedState(product.id, true);
+      expect((await inventoryService.getProduct(product.id))?.isChecked).toBe(true);
+
+      // Add to list - should reset isChecked to false
+      await shoppingService.addToList(product.id);
+
+      const updated = await inventoryService.getProduct(product.id);
+      expect(updated?.isChecked).toBe(false);
+      expect(updated?.isOnShoppingList).toBe(true);
+    });
   });
 
   describe('removeFromList', () => {
@@ -155,6 +190,46 @@ describe('ShoppingService', () => {
 
       const updated = await inventoryService.getProduct(product.id);
       expect(updated?.stockLevel).toBe(originalStock);
+    });
+
+    it('Story 11.8: should clear isChecked when removing from list', async () => {
+      const product = await inventoryService.addProduct('Cheese');
+      await shoppingService.addToList(product.id);
+
+      // Mark as bought
+      await shoppingService.updateCheckedState(product.id, true);
+      expect((await inventoryService.getProduct(product.id))?.isChecked).toBe(true);
+
+      // Remove from list - should clear isChecked
+      await shoppingService.removeFromList(product.id);
+
+      const updated = await inventoryService.getProduct(product.id);
+      expect(updated?.isOnShoppingList).toBe(false);
+      expect(updated?.isChecked).toBe(false);
+    });
+
+    it('Story 11.8: should prevent re-added as bought bug scenario', async () => {
+      const product = await inventoryService.addProduct('Yogurt');
+
+      // Scenario: Product runs low → auto-added
+      await inventoryService.updateProduct(product.id, { stockLevel: 'low' });
+      expect((await inventoryService.getProduct(product.id))?.isOnShoppingList).toBe(true);
+
+      // User marks as bought
+      await shoppingService.updateCheckedState(product.id, true);
+      expect((await inventoryService.getProduct(product.id))?.isChecked).toBe(true);
+
+      // User removes from list
+      await shoppingService.removeFromList(product.id);
+      expect((await inventoryService.getProduct(product.id))?.isOnShoppingList).toBe(false);
+      expect((await inventoryService.getProduct(product.id))?.isChecked).toBe(false);
+
+      // Product runs low again → auto-added
+      await inventoryService.updateProduct(product.id, { stockLevel: 'low' });
+
+      const updated = await inventoryService.getProduct(product.id);
+      expect(updated?.isOnShoppingList).toBe(true);
+      expect(updated?.isChecked).toBe(false); // Should NOT be checked
     });
   });
 
@@ -391,6 +466,45 @@ describe('ShoppingService', () => {
 
       const items = await shoppingService.getShoppingListItems();
       expect(items).toHaveLength(0);
+    });
+
+    it('Story 11.8: should clear isChecked even when isOnShoppingList is false (receipt flow)', async () => {
+      // Simulate receipt flow:
+      // 1. Product is on shopping list and marked as bought
+      const product = await inventoryService.addProduct('Milk');
+      await shoppingService.addToList(product.id);
+      await shoppingService.updateCheckedState(product.id, true);
+
+      expect((await inventoryService.getProduct(product.id))?.isOnShoppingList).toBe(true);
+      expect((await inventoryService.getProduct(product.id))?.isChecked).toBe(true);
+
+      // 2. replenishStock() sets isOnShoppingList: false BEFORE calling removePurchasedItems
+      await db.products.update(product.id, { isOnShoppingList: false });
+      expect((await inventoryService.getProduct(product.id))?.isOnShoppingList).toBe(false);
+      expect((await inventoryService.getProduct(product.id))?.isChecked).toBe(true); // Still true!
+
+      // 3. removePurchasedItems() should clear isChecked regardless of isOnShoppingList state
+      await shoppingService.removePurchasedItems(['Milk']);
+
+      // Verify isChecked is cleared even though isOnShoppingList was already false
+      const updated = await inventoryService.getProduct(product.id);
+      expect(updated?.isChecked).toBe(false);
+    });
+
+    it('Story 11.8: should clear isChecked for products on shopping list', async () => {
+      // Normal flow: product is on list and marked as bought
+      const product = await inventoryService.addProduct('Bread');
+      await shoppingService.addToList(product.id);
+      await shoppingService.updateCheckedState(product.id, true);
+
+      expect((await inventoryService.getProduct(product.id))?.isChecked).toBe(true);
+
+      // removePurchasedItems should clear isChecked
+      await shoppingService.removePurchasedItems(['Bread']);
+
+      const updated = await inventoryService.getProduct(product.id);
+      expect(updated?.isOnShoppingList).toBe(false);
+      expect(updated?.isChecked).toBe(false);
     });
   });
 });

--- a/src/services/shopping.ts
+++ b/src/services/shopping.ts
@@ -51,8 +51,11 @@ export class ShoppingService {
     try {
       logger.debug('Adding product to shopping list', { productId });
 
-      // Directly set isOnShoppingList to true without modifying stockLevel
-      await db.products.update(productId, { isOnShoppingList: true });
+      // Story 11.8: Always initialize isChecked as false when adding to list
+      await db.products.update(productId, {
+        isOnShoppingList: true,
+        isChecked: false,
+      });
 
       logger.info('Product added to shopping list', { productId });
     } catch (error) {
@@ -66,8 +69,12 @@ export class ShoppingService {
     try {
       logger.debug('Removing product from shopping list', { productId });
 
-      // Directly set isOnShoppingList to false without modifying stockLevel
-      await db.products.update(productId, { isOnShoppingList: false });
+      // Story 11.8: Clear isChecked flag when removing from list
+      // This prevents items from re-appearing as "bought" if added again
+      await db.products.update(productId, {
+        isOnShoppingList: false,
+        isChecked: false,
+      });
 
       logger.info('Product removed from shopping list', { productId });
     } catch (error) {
@@ -147,8 +154,10 @@ export class ShoppingService {
           const product = await inventoryService.findExistingProduct(name);
 
           if (product && product.isOnShoppingList) {
+            // Story 11.8: Clear isChecked flag for consistency
             await db.products.update(product.id!, {
               isOnShoppingList: false,
+              isChecked: false,
             });
             removedCount++;
             logger.info(`Removed from shopping list: ${name}`);

--- a/src/services/shopping.ts
+++ b/src/services/shopping.ts
@@ -153,19 +153,26 @@ export class ShoppingService {
         for (const name of productNames) {
           const product = await inventoryService.findExistingProduct(name);
 
-          if (product && product.isOnShoppingList) {
-            // Story 11.8: Clear isChecked flag for consistency
+          if (product) {
+            // Story 11.8: Clear both isOnShoppingList AND isChecked for ANY matched product
+            // This is important because replenishStock() sets isOnShoppingList: false
+            // before calling this method, so we can't rely on isOnShoppingList state
+            const wasOnShoppingList = product.isOnShoppingList;
+
             await db.products.update(product.id!, {
               isOnShoppingList: false,
               isChecked: false,
             });
-            removedCount++;
-            logger.info(`Removed from shopping list: ${name}`);
+
+            if (wasOnShoppingList) {
+              removedCount++;
+            }
+            logger.info(`Processed purchased product: ${name}`);
           }
         }
       });
 
-      logger.info('Purchased items removed from shopping list', { count: removedCount });
+      logger.info('Purchased items processed', { count: removedCount });
       return removedCount;
     } catch (error) {
       const appError = handleError(error);


### PR DESCRIPTION
## Summary

Fixed bug where items marked as "bought" in the shopping list would retain that status after being removed and re-added later.

## Problem

When an item was:
1. Marked as "bought" (isChecked: true) during shopping
2. Removed from the shopping list
3. Re-added later (auto or manual)

The item would appear with the "bought" checkbox still checked from the previous shopping session.

### Problem Flow

1. Product runs low → Auto-added to shopping list (isChecked: false) ✓
2. User marks product as "bought" (isChecked: true) ✓
3. User removes product from list → `isOnShoppingList: false`, but `isChecked: true` persists ✗
4. Product runs low again → Auto-added → `isChecked: still true` from before ✗

## Root Cause

The `removeFromList()` method only cleared `isOnShoppingList` but did NOT clear the `isChecked` flag.

**Before (BUGGY):**
```typescript
await db.products.update(productId, {
  isOnShoppingList: false,  // Cleared
  // isChecked: NOT CLEARED ❌
});
```

## Solution

Updated three methods to properly clear `isChecked` flag:

1. **removeFromList()** - Clear isChecked when manually removing
2. **addToList()** - Explicitly set isChecked: false when adding (defense in depth)
3. **removePurchasedItems()** - Clear isChecked for consistency

**After (FIXED):**
```typescript
await db.products.update(productId, {
  isOnShoppingList: false,
  isChecked: false,  // ✅ Clear the "bought" status
});
```

## Acceptance Criteria Met

✅ **AC1:** Both isOnShoppingList AND isChecked are cleared when item is removed
✅ **AC2:** Items re-added to list appear with "bought" checkbox UNCHECKED
✅ **AC3:** Manual add always starts with checkbox unchecked

## Changes

- `src/services/shopping.ts`
  - Updated `removeFromList()` to clear `isChecked` flag
  - Updated `addToList()` to explicitly set `isChecked: false`
  - Updated `removePurchasedItems()` to clear `isChecked` for consistency

## Testing

- All 692 tests passing
- Build successful

## Manual Verification

1. Add product to shopping list with Low stock
2. Mark product as "bought" (checkbox checked)
3. Remove product from shopping list
4. Change product stock to Low again → Auto-added to shopping list
5. ✅ Product appears with checkbox UNCHECKED

🤖 Generated with [Claude Code](https://claude.com/claude-code)